### PR TITLE
Multi oled support

### DIFF
--- a/Firmware/Arduino/libraries/SFE_MicroOLED/SFE_MicroOLED.cpp
+++ b/Firmware/Arduino/libraries/SFE_MicroOLED/SFE_MicroOLED.cpp
@@ -53,12 +53,9 @@ const unsigned char *MicroOLED::fontsPointer[]={
 	,fontlargenumber
 };
 
-/** \brief MicroOLED screen buffer.
-
-Page buffer 64 x 48 divided by 8 = 384 bytes
-Page buffer is required because in SPI mode, the host cannot read the SSD1306's GDRAM of the controller.  This page buffer serves as a scratch RAM for graphical functions.  All drawing function will first be drawn on this page buffer, only upon calling display() function will transfer the page buffer to the actual LCD controller's memory.
+/** \brief SparkFun logo bitmap for screen buffer.
 */
-static uint8_t screenmemory [] = { 
+static uint8_t sparkfunLogoBitmap [] = {
 	/* LCD Memory organised in 64 horizontal pixel and 6 rows of byte
 	 B  B .............B  -----
 	 y  y .............y        \
@@ -168,10 +165,23 @@ MicroOLED::MicroOLED(uint8_t rst, uint8_t dc, uint8_t cs, uint8_t wr, uint8_t rd
 
 /** \brief Initialisation of MicroOLED Library.
 
-    Setup IO pins for SPI port then send initialisation commands to the SSD1306 controller inside the OLED. 
+    Setup IO pins for SPI port then send initialisation commands to the SSD1306 controller inside the OLED.
 */
-void MicroOLED::begin() 
-{	
+void MicroOLED::begin()
+{
+	setup();
+	initialize();
+	loadSparkFunLogo();
+}
+
+/** \brief Setup IO pins for SPI port.
+
+    Setup IO pins for SPI port
+*/
+void MicroOLED::setup()
+{
+	clear(PAGE);
+
 	// default 5x7 font
 	setFontType(0);
 	setColor(WHITE);
@@ -200,7 +210,14 @@ void MicroOLED::begin()
 	digitalWrite(rstPin, LOW);	// Bring RST low, reset the display
 	delay(10);	// wait 10ms
 	digitalWrite(rstPin, HIGH);	// Set RST HIGH, bring out of reset
+}
 
+/** \brief Initialisation of MicroOLED.
+
+    Send initialisation commands to the SSD1306 controller inside the OLED.
+*/
+void MicroOLED::initialize()
+{
 	// Display Init sequence for 64x48 OLED module
 	command(DISPLAYOFF);			// 0xAE
 
@@ -922,4 +939,13 @@ void MicroOLED::drawBitmap(uint8_t * bitArray)
 {
   for (int i=0; i<(LCDWIDTH * LCDHEIGHT / 8); i++)
     screenmemory[i] = bitArray[i];
+}
+
+/** \brief Horizontal flip.
+
+    Flip the graphics on the OLED horizontally.
+*/
+void MicroOLED::loadSparkFunLogo(void)
+{
+	drawBitmap(sparkfunLogoBitmap);
 }

--- a/Firmware/Arduino/libraries/SFE_MicroOLED/SFE_MicroOLED.h
+++ b/Firmware/Arduino/libraries/SFE_MicroOLED/SFE_MicroOLED.h
@@ -129,8 +129,13 @@ public:
 	MicroOLED(uint8_t rst, uint8_t dc, uint8_t cs, uint8_t wr, uint8_t rd, 
 			  uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3, 
 			  uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7);
-	
+
+	// Call begin()
 	void begin(void);
+	// or call these pair
+	void setup(void);
+	void initialize(void);
+
 	virtual size_t write(uint8_t);
 
 	// RAW LCD functions
@@ -188,8 +193,12 @@ public:
 	void scrollStop(void);
 	void flipVertical(boolean flip);
 	void flipHorizontal(boolean flip);
-	
+
+	// SparkFun Splash Screen
+	void loadSparkFunLogo(void);
+
 private:
+	uint8_t screenmemory[384];
 	uint8_t csPin, dcPin, rstPin;
 	uint8_t wrPin, rdPin, dPins[8];
 	volatile uint8_t *wrport, *wrreg, *rdport, *rdreg;

--- a/Firmware/Arduino/libraries/SFE_MicroOLED/examples/MicroOLED_Multi/MicroOLED_Multi.ino
+++ b/Firmware/Arduino/libraries/SFE_MicroOLED/examples/MicroOLED_Multi/MicroOLED_Multi.ino
@@ -1,0 +1,127 @@
+/******************************************************************************
+  MicroOLED_Multi.ino
+  SFE_MicroOLED Multi OLED Demo
+  Basuke Suzuki @basuke
+  Original Creation Date: February 3, 2015
+
+  This sketch demonstrates how to use multiple MicroOLED
+  breakout boards from one Arduino.
+
+  Hardware Connections:
+    We'll be using the SPI interface on the MicroOLED.
+
+    MicroOLED 1 ----------- Arduino
+      GND ------------------- GND
+      VDD ------------------- 3.3V (VCC)
+    D1/MOSI ----------------- D11 (don't change)
+    D0/SCK ------------------ D13 (don't change)
+      D2
+      D/C ------------------- D8 (can be any digital pin)
+      RST ------------------- D9 (can be any digital pin)
+      CS  ------------------- D10 (can be any digital pin)
+
+    MicroOLED 2 ----------- Arduino
+      GND ------------------- GND
+      VDD ------------------- 3.3V (VCC)
+    D1/MOSI ----------------- D11 (don't change)
+    D0/SCK ------------------ D13 (don't change)
+      D2
+      D/C ------------------- D8 (shaed with first one)
+      RST ------------------- D9 (shaed with first one)
+      CS  ------------------- D7 (can be any digital pin,
+                                  but not the same with first one)
+
+  Development environment specifics:
+  	IDE: Arduino 1.0.5
+  	Hardware Platform: MicroOLED Breakout
+                           Arduino Pro Mini 3.3V/8MHz
+
+  Note: The display on the MicroOLED is a 1.8V-3.3V device only.
+  Don't try to connect a 5V Arduino directly to it! Use level
+  shifters in between the data signals if you have to resort to
+  a 5V board.
+
+  This code is beerware; if you see me (or any other SparkFun
+  employee, or @basuke) at the local, and you've found our code helpful,
+  please buy us a round!
+
+  Distributed as-is; no warranty is given.
+*******************************************************************************/
+#include <Wire.h>  // Include Wire if you're using I2C
+#include <SPI.h>  // Include SPI if you're using SPI
+#include <SFE_MicroOLED.h>  // Include the SFE_MicroOLED library
+
+//////////////////////////
+// MicroOLED Definition //
+//////////////////////////
+#define PIN_RESET 9  // Connect RST to pin 9
+#define PIN_DC    8  // Connect DC to pin 8
+#define PIN_CS_1  10 // Connect first CS to pin 10
+#define PIN_CS_2  7  // Connect second CS to pin 7
+
+//////////////////////////////////
+// MicroOLED Object Declaration //
+//////////////////////////////////
+// Declare a MicroOLED object. The parameters include:
+// 1 - Reset pin: Any digital pin
+// 2 - D/C pin: Any digital pin (SPI mode only)
+// 3 - CS pin: Any digital pin (SPI mode only, 10 recommended)
+MicroOLED oled1(PIN_RESET, PIN_DC, PIN_CS_1);
+MicroOLED oled2(PIN_RESET, PIN_DC, PIN_CS_2);
+
+void setup()
+{
+  // These three lines of code are all you need to initialize the
+  // OLED and print the splash screen.
+
+  // To use multiple MicroOLED boards, begin() cannot be used.
+  // Insted, use pair of setup() and initialize() in that order.
+
+  // Congigure pins to control OLEDs
+  oled1.setup();
+  oled2.setup();
+
+  // Send initialize commands to each OLEDs
+  oled1.initialize();
+  oled2.initialize();
+
+  // Display SparkFun logo as the splash screen only for first OLED
+  oled1.loadSparkFunLogo();
+  oled1.display();
+
+  delay(1000);
+
+  oled1.setFontType(1);
+  oled2.setFontType(1);
+}
+
+void loop()
+{
+  oled1.clear(PAGE);
+  oled2.clear(PAGE);
+
+  oled1.setCursor(0, 0);
+  oled2.setCursor(0, 0);
+
+  oled1.print("Hello");
+  oled2.print("world!");
+
+  oled1.display();
+  oled2.display();
+
+  delay(2000);
+
+  oled1.clear(PAGE);
+  oled2.clear(PAGE);
+
+  oled1.setCursor(0, 0);
+  oled2.setCursor(0, 0);
+
+  oled1.print("See you");
+  oled2.print("again.");
+
+  oled1.display();
+  oled2.display();
+
+  delay(2000);
+}

--- a/Firmware/Arduino/libraries/SFE_MicroOLED/keywords.txt
+++ b/Firmware/Arduino/libraries/SFE_MicroOLED/keywords.txt
@@ -13,6 +13,8 @@ MicroOLED	KEYWORD1
 #######################################
 
 begin	KEYWORD2
+setup	KEYWORD2
+initialize	KEYWORD2
 invert	KEYWORD2
 clear	KEYWORD2
 invert	KEYWORD2
@@ -46,6 +48,7 @@ scrollVertLeft	KEYWORD2
 scrollStop	KEYWORD2
 flipVertical	KEYWORD2
 flipHorizontal	KEYWORD2
+loadSparkFunLogo	KEYWORD2
 
 getX	KEYWORD2
 getY	KEYWORD2


### PR DESCRIPTION
I tried to use two MicroOLED breakout boards with one Arduino Pro Mini, but it failed. I checked with the library and found begin() was doing wrong. Actually if I split begin() into two parts and call them in that order, it worked.

Not like this to setup():

```
  oled1.begin();
  oled2.begin();
```

but like this:

```
  oled1.setup();
  oled2.setup();

  oled1.initialize();
  oled2.initialize();
```

Please check the example ino file.
